### PR TITLE
Display post descriptions/excerpts on index page

### DIFF
--- a/_assets/stylesheets/_index.scss
+++ b/_assets/stylesheets/_index.scss
@@ -2,4 +2,10 @@
     li {
         margin-bottom: 21px;
     }
+
+    .posts-excerpt {
+      font-style: italic;
+      font-size: 1.65rem;
+      color: $dark-grey;
+    }
 }

--- a/_posts/2015-09-02-tomcat-slashes.md
+++ b/_posts/2015-09-02-tomcat-slashes.md
@@ -2,6 +2,7 @@
 title:  Tomcat Hates Encoded Slashes
 author: Ray Nicholus
 categories: Tomcat server HTTP REST Java JavaScript
+excerpt: ""
 ---
 
 ## Setup

--- a/index.html
+++ b/index.html
@@ -9,11 +9,13 @@ layout: default
             <a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
           </h1>
 
-          {% if post.excerpt != blank %}
-            <p class="posts-excerpt">{{ post.excerpt }}</p>
-          {% else %}
-            <p class="posts-excerpt">{{ post.content | strip_html | truncatewords: 50 }}</p>
-          {% endif %}
+          <p class="posts-excerpt">
+            {% if post.excerpt != '' %}
+              {{ post.excerpt | truncatewords: 50 | remove: '<p>' | remove: '</p>' }}
+            {% else %}
+              {{ post.content | strip_html | truncatewords: 50 }}
+            {% endif %}
+          </p>
 
           <time>{{ post.date | date: "%b %-d, %Y" }}</time> • {{post.author}}
         </li>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@ layout: default
           <h1>
             <a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
           </h1>
+          <p class="posts-excerpt">{{ post.content | strip_html | truncatewords: 50 }}</p>
           <time>{{ post.date | date: "%b %-d, %Y" }}</time> • {{post.author}}
         </li>
       {% endfor %}

--- a/index.html
+++ b/index.html
@@ -8,7 +8,13 @@ layout: default
           <h1>
             <a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
           </h1>
-          <p class="posts-excerpt">{{ post.content | strip_html | truncatewords: 50 }}</p>
+
+          {% if post.excerpt != blank %}
+            <p class="posts-excerpt">{{ post.excerpt }}</p>
+          {% else %}
+            <p class="posts-excerpt">{{ post.content | strip_html | truncatewords: 50 }}</p>
+          {% endif %}
+
           <time>{{ post.date | date: "%b %-d, %Y" }}</time> • {{post.author}}
         </li>
       {% endfor %}


### PR DESCRIPTION
If an an non-empty excerpt exists on the post, we'll use it, else we'll parse the post content.

#9 