### PR TITLE
feat(authors): add pages and links

### DIFF
--- a/_data/team.yml
+++ b/_data/team.yml
@@ -1,9 +1,16 @@
 members:
-    mfeltner:
-      email: mfeltner@widen.com
-      github: feltnerm
-      name: "Mark Feltner"
-    dbeg:
-      email: dbeghin@widen.com
-      github: dbeg
-      name: "Dan Beghin"
+  feltnerm:
+    email: mfeltner@widen.com
+    github: feltnerm
+    name: "Mark Feltner"
+    description: This is an author's biography... blah blah blah.
+  dbeg:
+    email: dbeghin@widen.com
+    github: dbeg
+    name: "Dan Beghin"
+    description: This is an author's biography... blah blah blah.
+  rnicholus:
+    name: "Ray Nicholus"
+    github_username: "rnicholus"
+    email: "rnicholus@widen.com"
+    description: This is an author's biography... blah blah blah.

--- a/_includes/author.html
+++ b/_includes/author.html
@@ -1,0 +1,11 @@
+{% if post.author %}
+  {% assign title = post.title %}
+  {% assign url = post.url %}
+{% elsif page.author %}
+  {% assign title = page.title %}
+  {% assign url = page.url %}
+{% endif %}
+
+{% if title %}
+  <p><a href="{{ url | prepend: site.baseurl }}">{{ title }}</a></p>
+{% endif %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,9 +4,11 @@
           <ul class="inline">
           {% for page in site.pages %}
             {% if page.title %}
-            <li>
-                <a href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
-            </li>
+              {% unless page.url contains '/authors/' %}
+                <li>
+                    <a href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
+                </li>
+              {% endunless %}
             {% endif %}
           {% endfor %}
           </ul>

--- a/_layouts/author_index.html
+++ b/_layouts/author_index.html
@@ -1,0 +1,18 @@
+---
+layout: page
+---
+
+<div>
+	{% for post in site.posts %}
+    {% if post.author contains page.author %}
+        {% capture this_year %}{{ post.date | date: "%Y" }}{% endcapture %}
+
+				{% unless year == this_year %}
+          {% assign year = this_year %}
+          <h2>{{ year }}</h2>
+        {% endunless %}
+
+  			{% include author.html %}
+    {% endif %}
+	{% endfor %}
+</div>

--- a/_layouts/author_index.html
+++ b/_layouts/author_index.html
@@ -1,18 +1,33 @@
 ---
-layout: page
+layout: default
 ---
 
-<div>
-	{% for post in site.posts %}
-    {% if post.author contains page.author %}
-        {% capture this_year %}{{ post.date | date: "%Y" }}{% endcapture %}
+<div class="page">
+    <header>
+      <h1>{{ site.data.team.members[page.title].name }}</h1>
+    </header>
 
-				{% unless year == this_year %}
-          {% assign year = this_year %}
-          <h2>{{ year }}</h2>
-        {% endunless %}
+		<article role="article">
 
-  			{% include author.html %}
-    {% endif %}
-	{% endfor %}
+			<p>{{ site.data.team.members[page.title].description }}</p>
+
+			<h2>{{ site.data.team.members[page.title].name | split: ' ' | first }}'s Posts</h2>
+
+			{% for post in site.posts %}
+		    {% if post.author contains page.author %}
+
+		        {% capture this_year %}{{ post.date | date: "%Y" }}{% endcapture %}
+
+						{% unless year == this_year %}
+		          {% assign year = this_year %}
+		          <h3>{{ year }}</h3>
+		        {% endunless %}
+
+		  			{% include author.html %}
+		    {% endif %}
+			{% endfor %}
+
+			<p>Follow {{ site.data.team.members[page.title].name | split: ' ' | first }} on <a href="https://github.com/{{ site.data.team.members[page.title].github }}">GitHub</a>.</p>
+
+	</article>
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,7 +4,18 @@ layout: default
 <div class="post">
     <header>
         <h1><a title="{{page.title}}" href="{{page.url}}">{{ page.title }}</a></h1>
-        <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%b %-d, %Y" }}</time>{% if page.author %} • {% if site.data.team.members[page.author] %}<a href="#">{{ site.data.team.members[page.author].name }}</a>{% else %}{{ page.author }}{% endif %}{% endif %}{% if page.meta %} • {{ page.meta }}{% endif %}
+        <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%b %-d, %Y" }}</time>
+        {% if page.author %}
+          • 
+          {% if site.data.team.members[page.author] %}
+            <a href="#">{{ site.data.team.members[page.author].name }}</a>
+          {% else %}
+            <a href="/authors/{{ page.author | downcase | cgi_escape }}">{{ page.author }}</a>
+          {% endif %}
+        {% endif %}
+        {% if page.meta %}
+          • {{ page.meta }}
+        {% endif %}
     </header>
 
     <article role="article">

--- a/_plugins/author_generator.rb
+++ b/_plugins/author_generator.rb
@@ -1,0 +1,147 @@
+# encoding: utf-8
+#
+# Jekyll author page generator.
+# http://recursive-design.com/projects/jekyll-plugins/
+#
+# Version: 0.1.4 (201101061053)
+#
+# Copyright (c) 2010 Dave Perrett, http://recursive-design.com/
+# Licensed under the MIT license (http://www.opensource.org/licenses/mit-license.php)
+#
+# A generator that creates author pages for jekyll sites.
+#
+# Included filters :
+# - author_links:      Outputs the list of author as comma-separated <a> links.
+# - date_to_html_string: Outputs the post.date as formatted html, with hooks for CSS styling.
+#
+# Available _config.yml settings :
+# - author_dir:          The subfolder to build author pages in (default is 'authors').
+# - author_title_prefix: The string used before the author name in the page title (default is
+#                          'Author: ').
+
+module Jekyll
+
+  # The AuthorIndex class creates a single author page for the specified author.
+  class AuthorIndex < Page
+
+    # Initializes a new AuthorIndex.
+    #
+    #  +base+         is the String path to the <source>.
+    #  +author_dir+ is the String path between <source> and the author folder.
+    #  +author+     is the author currently being processed.
+    def initialize(site, base, author_dir, author)
+      @site = site
+      @base = base
+      @dir  = author_dir
+      @name = 'index.html'
+      puts "author #{author} @dir #{author_dir}"
+      self.process(@name)
+      # Read the YAML data from the layout page.
+      self.read_yaml(File.join(base, '_layouts'), 'author_index.html')
+      self.data['author']    = author
+      # Set the title for this page.
+      title_prefix             = site.config['author_title_prefix'] || 'author: '
+      self.data['title']       = "#{author}"
+      # Set the meta-description for this page.
+      meta_description_prefix  = site.config['author_meta_description_prefix'] || 'author: '
+      self.data['description'] = "#{meta_description_prefix}#{author}"
+    end
+
+  end
+
+
+  # The Site class is a built-in Jekyll class with access to global site config information.
+  class Site
+
+    # Creates an instance of AuthorIndex for each author page, renders it, and
+    # writes the output to a file.
+    #
+    #  +author_dir+ is the String path to the author folder.
+    #  +author+     is the author currently being processed.
+    def write_author_index(author_dir, author)
+      index = AuthorIndex.new(self, self.source, author_dir, author)
+      index.render(self.layouts, site_payload)
+      index.write(self.dest)
+      # Record the fact that this page has been added, otherwise Site::cleanup will remove it.
+      self.pages << index
+
+    end
+
+    # Loops through the list of author pages and processes each one.
+    def write_author_indexes
+      if self.layouts.key? 'author_index'
+        dir = self.config['author_dir'] || 'authors'
+        self.posts.each do |post|
+          post_authors = post.data["author"]
+          if String.try_convert(post_authors)
+               post_authors = [ post_authors ]
+          end
+          post_authors.each do |author|
+            self.write_author_index(File.join(dir, author.downcase.gsub(' ', '+')), author)
+          end unless post_authors.nil?
+        end
+      # Throw an exception if the layout couldn't be found.
+      else
+        throw "No 'author_index' layout found."
+      end
+    end
+
+  end
+
+
+  # Jekyll hook - the generate method is called by jekyll, and generates all of the author pages.
+  class GenerateAuthor < Generator
+    safe true
+    priority :high
+
+    def generate(site)
+      site.write_author_indexes
+      #puts "site.authors #{site.authors}"
+    end
+
+  end
+
+
+  # Adds some extra filters used during the author creation process.
+  module Filters
+
+    # Outputs a list of authors as comma-separated <a> links. This is used
+    # to output the author list for each post on a author page.
+    #
+    #  +author+ is the list of author to format.
+    #
+    # Returns string
+    #
+    def author_links(authors)
+      dir = @context.registers[:site].config['author_dir'] || "authors"
+      if String.try_convert(authors)
+               authors = [ authors ]
+      end
+      authors = authors.map do |author|
+        "<a class='author' href='/#{dir}/#{author.downcase.gsub(' ', '+')}/'>#{author}</a>"
+      end
+      case authors.length
+      when 0
+        ""
+      when 1
+        authors[0].to_s
+      else
+        "#{authors[0...-1].join(', ')}, #{authors[-1]}"
+      end
+    end
+
+    # Outputs the post.date as formatted html, with hooks for CSS styling.
+    #
+    #  +date+ is the date object to format as HTML.
+    #
+    # Returns string
+    def date_to_html_string(date)
+      result = '<span class="month">' + date.strftime('%b').upcase + '</span> '
+      result += date.strftime('<span class="day">%d</span> ')
+      result += date.strftime('<span class="year">%Y</span> ')
+      result
+    end
+
+  end
+
+end

--- a/_posts/2015-08-27-AWS-Lambda-Runtime-Configuration.md
+++ b/_posts/2015-08-27-AWS-Lambda-Runtime-Configuration.md
@@ -1,6 +1,6 @@
 ---
 title:  Runtime Configuration for AWS' Lambda
-author: Mark Feltner
+author: feltnerm
 categories: aws lambda hack
 published: true
 permalink: /blog/2015/08/27/AWS-Lambda-Runtime-Configuration

--- a/_posts/2015-09-02-tomcat-slashes.md
+++ b/_posts/2015-09-02-tomcat-slashes.md
@@ -1,6 +1,6 @@
 ---
 title:  Tomcat Hates Encoded Slashes
-author: Ray Nicholus
+author: rnicholus
 categories: Tomcat server HTTP REST Java JavaScript
 excerpt: "After sending a GET request containing escaped slashes to our Tomcat-hosted endpoint, we expect to receive a 2xx response. But instead, our server responds with a 404. What happened?"
 ---

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@ layout: default
           </p>
 
           <time>{{ post.date | date: "%b %-d, %Y" }}</time>
-           • <a href="/authors/{{ post.author | downcase | cgi_escape }}">{{post.author}}</a>
+           • <a href="/authors/{{ post.author | downcase | cgi_escape }}">{{ site.data.team.members[post.author].name }}</a>
         </li>
       {% endfor %}
     </ul>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,8 @@ layout: default
             {% endif %}
           </p>
 
-          <time>{{ post.date | date: "%b %-d, %Y" }}</time> • {{post.author}}
+          <time>{{ post.date | date: "%b %-d, %Y" }}</time>
+           • <a href="/authors/{{ post.author | downcase | cgi_escape }}">{{post.author}}</a>
         </li>
       {% endfor %}
     </ul>


### PR DESCRIPTION
Related to issue #12 
#### Features
- author pages are now being generated during the Jekyll build process
  - each author page contains a list of their linked posts with year headings
  - these pages are iterated within `footer.html` and are currently being displayed on `index.html`... we should probably filter author pages out and display them in some other capacity
- author name on index and post is now a link to their respective page
#### Todo

At the minimum before merging, we should remove the page links from displaying on `index.html`
