### PR TITLE
feat(feed): enable email subscription

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ baseurl: "" # the subpath of your site, e.g. /blog/
 url: "https://engineering.widen.com"
 email: "engineering@widen.com"
 
-remote_theme: widen/jekyll-theme-guardian@v0.0.2
+remote_theme: widen/jekyll-theme-guardian@v1.0.1
 guardian:
   style:
     logo_url: https://embed.widencdn.net/img/widen/c17yrvuaac/400px@2x/Widen Engineering White Logo.png?u=mcuc7i
@@ -14,6 +14,7 @@ guardian:
     twitter: widendev
     github_org: widen
     github_repo: widen.github.io
+    email_subscription_url: https://feedburner.google.com/fb/a/mailverify?uri=WidenEngineering
   tracking:
     google_analytics_code: UA-1206716-19
     disqus_shortname: widen-engineering


### PR DESCRIPTION
I created a similar Feedburner config for the engineering blog and quickly enabled here with a simple theme version upgrade and populating the new config option.

I used very similar style/copy text in the email messaging. If anyone wants to see what the flow will actually be, clicking the new email icon in the footer will open this url in a new tab: https://feedburner.google.com/fb/a/mailverify?uri=WidenEngineering