### PR TITLE
Accessibility improvements

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ baseurl: "" # the subpath of your site, e.g. /blog/
 url: "https://engineering.widen.com"
 email: "engineering@widen.com"
 
-remote_theme: "widen/jekyll-theme-guardian@v1.2.0"
+remote_theme: "widen/jekyll-theme-guardian@v1.4.0"
 guardian:
   style:
     logo_url: https://embed.widencdn.net/img/widen/c17yrvuaac/400px@2x/Widen Engineering White Logo.png?u=mcuc7i

--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ baseurl: "" # the subpath of your site, e.g. /blog/
 url: "https://engineering.widen.com"
 email: "engineering@widen.com"
 
-remote_theme: "widen/jekyll-theme-guardian@v1.4.0"
+remote_theme: "widen/jekyll-theme-guardian@1.4.0"
 guardian:
   style:
     logo_url: https://embed.widencdn.net/img/widen/c17yrvuaac/400px@2x/Widen Engineering White Logo.png?u=mcuc7i

--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ baseurl: "" # the subpath of your site, e.g. /blog/
 url: "https://engineering.widen.com"
 email: "engineering@widen.com"
 
-remote_theme: "widen/jekyll-theme-guardian@1.4.0"
+remote_theme: "widen/jekyll-theme-guardian@v1.4.0"
 guardian:
   style:
     logo_url: https://embed.widencdn.net/img/widen/c17yrvuaac/400px@2x/Widen Engineering White Logo.png?u=mcuc7i

--- a/_data/team.yml
+++ b/_data/team.yml
@@ -1,9 +1,29 @@
 members:
-    mfeltner:
-      email: mfeltner@widen.com
-      github: feltnerm
-      name: "Mark Feltner"
-    dbeg:
-      email: dbeghin@widen.com
-      github: dbeg
-      name: "Dan Beghin"
+  bdotte:
+    email: bdotte@widen.com
+    github: bdotte
+    name: "Ben Dotte"
+  dbeg:
+    email: dbeghin@widen.com
+    github: dbeg
+    name: "Dan Beghin"
+  jweaver:
+    email: jweaver@widen.com
+    github: jweaver-widen
+    name: "Jordan Weaver"
+  kbrinnehl:
+    email: kbrinnehl@widen.com
+    github: brinnehlops
+    name: "Kevin Brinnehl"
+  mfeltner:
+    email: mfeltner@widen.com
+    github: feltnerm
+    name: "Mark Feltner"
+  mskelton:
+    email: mskelton@widen.com
+    github: mskelton
+    name: "Mark Skelton"
+  twilco:
+    email: twilcock@widen.com
+    github: twilco
+    name: "Tyler Wilcock"

--- a/_posts/2021-04-24-Improving-CSS-Variables-in-WebKit.md
+++ b/_posts/2021-04-24-Improving-CSS-Variables-in-WebKit.md
@@ -14,14 +14,14 @@ the CSS variables implementation in WebKit.  Read on to learn more about CSS var
 
 Widen, like many companies, makes heavy use of open-source technology, and we've made it a part of our mission to give back to this community that we benefit so much from. In light of this, in this post I'll be talking about some improvements I made to the CSS variables implementation in WebKit.
 
-### What is WebKit?
+## What is WebKit?
 
 [WebKit](https://webkit.org/) is an open-source browser engine that is most famous for powering Safari.  Safari is far from the only place
  you'll find WebKit, however.  It's behind every browser on iOS, all web content displayed on PlayStation systems, and in various GTK-based browsers
 such as [Gnome Web](https://github.com/GNOME/epiphany).  WebKit is also deployed to millions of embedded
 devices via the [WebKit Port for Embedded](https://webkit.org/wpe/) (WPE) port.
 
-### CSS has variables?
+## CSS has variables?
 
 Yes!  You don't need a CSS preprocessor to use variables in your CSS.  Here's what the syntax looks like:
 
@@ -57,12 +57,12 @@ maximizeGutterButton.onclick = () => {
 
 CSS variables are also known as custom properties.  For a more detailed overview of CSS variables, read more [on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties).
 
-### Improvements to WebKit's CSS variables implementation
+## Improvements to WebKit's CSS variables implementation
 
 You can find the diff for each fixed bug by following the <a href="https://bugs.webkit.org">bugs.webkit.org</a> sub-header link and clicking "Formatted Diff" on the
 patch.
 
-#### Safer handling of overly long CSS variables
+### Safer handling of overly long CSS variables
 <div class="bugzilla-subheader"><a href="https://bugs.webkit.org/show_bug.cgi?id=216407">https://bugs.webkit.org/show_bug.cgi?id=216407</a></div>
 
 One useful property of CSS variables is that the value of one variable can be the expansion of another. However, this can get out of hand when used maliciously:
@@ -98,7 +98,7 @@ snippet where the `background-color` for `.foo` is either `--optional-theme-colo
 Before this patch, CSS-wide keywords were not parsed in the context of variable fallbacks, and therefore were always considered invalid values.  This
 includes `inherit`, `initial`, `revert`, and `unset`.
 
-#### Resolve relative-path URLs in `url()` against the correct base URL when CSS variables are involved
+### Resolve relative-path URLs in `url()` against the correct base URL when CSS variables are involved
 <div class="bugzilla-subheader"><a href="https://bugs.webkit.org/show_bug.cgi?id=198512">https://bugs.webkit.org/show_bug.cgi?id=198512</a></div>
 
 Given this folder structure:
@@ -143,7 +143,7 @@ To fix this, WebKit's representation of [pending-substitution values](https://dr
 tracks the base URL that should be used to resolve any `url()` in the value, rather than unconditionally resolving them against the
 base document URL.
 
-#### Prevent :visited styles from erroneously being applied to non-visited links when CSS variables are present in the rule
+### Prevent :visited styles from erroneously being applied to non-visited links when CSS variables are present in the rule
 <div class="bugzilla-subheader"><a href="https://bugs.webkit.org/show_bug.cgi?id=210525">https://bugs.webkit.org/show_bug.cgi?id=210525</a></div>
 
 Given:
@@ -189,7 +189,7 @@ any time the function returns.
 Instead, any time this state is mutated during variable expansion, it's now done so with a utility within WebKit called
 `SetForScope`, which automatically rolls the changed state back to its original value when the `SetForScope` is destroyed.
 
-### Future work
+## Future work
 
 Currently, CSS variables used in `@keyframes` animations in WebKit [are broken](https://bugs.webkit.org/show_bug.cgi?id=201736).
 I haven't got around to fixing this one yet, but hope to do so soon.

--- a/index.html
+++ b/index.html
@@ -4,21 +4,23 @@ layout: default
 <div class="posts">
     <ul>
       {% for post in site.posts %}
-        <article>
-          <h1>
-            <a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
-          </h1>
+        <li style="list-style: none; margin-bottom: 0; padding-bottom: 0">
+          <article>
+            <h1>
+              <a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+            </h1>
 
-          <p class="posts-excerpt">
-            {% if post.excerpt != '' %}
-              {{ post.excerpt | truncatewords: 50 | remove: '<p>' | remove: '</p>' }}
-            {% else %}
-              {{ post.content | strip_html | truncatewords: 50 }}
-            {% endif %}
-          </p>
+            <p class="posts-excerpt">
+              {% if post.excerpt != '' %}
+                {{ post.excerpt | truncatewords: 50 | remove: '<p>' | remove: '</p>' }}
+              {% else %}
+                {{ post.content | strip_html | truncatewords: 50 }}
+              {% endif %}
+            </p>
 
-          <time>{{ post.date | date: "%b %-d, %Y" }}</time> • {{post.author}}
-        </article>
+            <time>{{ post.date | date: "%b %-d, %Y" }}</time> • {{post.author}}
+          </article>
+        </li>
       {% endfor %}
     </ul>
 </div>

--- a/index.html
+++ b/index.html
@@ -3,20 +3,20 @@ layout: default
 ---
 <div class="posts">
     {% for post in site.posts %}
-        <article>
-          <h1>
-            <a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
-          </h1>
+      <article>
+        <h1>
+          <a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+        </h1>
 
-          <p class="posts-excerpt">
-            {% if post.excerpt != '' %}
-              {{ post.excerpt | truncatewords: 50 | remove: '<p>' | remove: '</p>' }}
-            {% else %}
-              {{ post.content | strip_html | truncatewords: 50 }}
-            {% endif %}
-          </p>
+        <p class="posts-excerpt">
+          {% if post.excerpt != '' %}
+            {{ post.excerpt | truncatewords: 50 | remove: '<p>' | remove: '</p>' }}
+          {% else %}
+            {{ post.content | strip_html | truncatewords: 50 }}
+          {% endif %}
+        </p>
 
-          <time>{{ post.date | date: "%b %-d, %Y" }}</time> • {{post.author}}
-        </article>
+        <time>{{ post.date | date: "%b %-d, %Y" }}</time> • {{post.author}}
+      </article>
     {% endfor %}
 </div>

--- a/index.html
+++ b/index.html
@@ -2,25 +2,21 @@
 layout: default
 ---
 <div class="posts">
-    <ul>
-      {% for post in site.posts %}
-        <li style="list-style: none; margin-bottom: 0; padding-bottom: 0">
-          <article>
-            <h1>
-              <a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
-            </h1>
+    {% for post in site.posts %}
+        <article>
+          <h1>
+            <a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+          </h1>
 
-            <p class="posts-excerpt">
-              {% if post.excerpt != '' %}
-                {{ post.excerpt | truncatewords: 50 | remove: '<p>' | remove: '</p>' }}
-              {% else %}
-                {{ post.content | strip_html | truncatewords: 50 }}
-              {% endif %}
-            </p>
+          <p class="posts-excerpt">
+            {% if post.excerpt != '' %}
+              {{ post.excerpt | truncatewords: 50 | remove: '<p>' | remove: '</p>' }}
+            {% else %}
+              {{ post.content | strip_html | truncatewords: 50 }}
+            {% endif %}
+          </p>
 
-            <time>{{ post.date | date: "%b %-d, %Y" }}</time> • {{post.author}}
-          </article>
-        </li>
-      {% endfor %}
-    </ul>
+          <time>{{ post.date | date: "%b %-d, %Y" }}</time> • {{post.author}}
+        </article>
+    {% endfor %}
 </div>


### PR DESCRIPTION
This PR improves accessibility by:
* Updating the "Improving CSS Variables in WebKit" article to not skip heading levels. Screen readers use heading levels to understand web pages, so heading levels shouldn't be skipped purely for style reasons (which was the case in this article).
* Removing the `<ul>` list of posts on the landing page. Prior to this PR, we did not have `<li>` elements as the direct children of this list element, which [makes it harder for screen readers to announce the list](https://dequeuniversity.com/rules/axe/4.2/list?application=AxeFirefox). There is no value in having this `<ul>` AFAICT, so I removed it to avoid the issue. There is no visual impact resulting from this change.
* Upgrading to the latest Guardian theme. See improvements here: https://github.com/Widen/jekyll-theme-guardian/pull/15

This PR also adds all members of the WDRC to the `team.yaml` file.